### PR TITLE
Monoalphabetic substitution cipher

### DIFF
--- a/mono-substitution/mono.py
+++ b/mono-substitution/mono.py
@@ -40,7 +40,7 @@ def main():
 	descrip = 'A monoalphabetic substitution encrypter/decrypter. It is capable ' \
 			  'of encrypting with your key of choice or a with a key generated ' \
 			  'randomly by this program. It can read in a file or a string passed ' \
-			  'into the command line. If no output file is specified, the decryption' \
+			  'into the command line. If no output file is specified, the decryption ' \
 			  'will be printed to STDOUT.'
 	encrypt_help = 'This flag specifies that the input will be encrypted.'
 	decrypt_help = 'This flag specifies that the output will be decrypted.'

--- a/mono-substitution/mono.py
+++ b/mono-substitution/mono.py
@@ -91,11 +91,16 @@ def main():
 	encrypt = False
 	decrypt = False
 
+	# Flag for whether an output file was specified or not
+	output_specified = False
+
 	# Figure out whether we are encryption or decrypting
 	if args.encrypt == True:
 		encrypt = True
+		print('Encryption mode.')
 	else:
 		decrypt = True
+		print('Decryption mode.')
 
 	if args.txt_file is not None:
 		# An input text file was passed in as the text to encrypt
@@ -110,6 +115,7 @@ def main():
 	if args.out_file is not None:
 		# An output file name was specified
 		out_file_name = args.out_file
+		output_specified = True
 		print('Output file:', out_file_name)
 
 	# Figure out if a key is specified or if a random key will have to be generated
@@ -121,7 +127,7 @@ def main():
 		else:
 			# An invalid key was passed in by the user, die gracefully w/ error message
 			# Implement this -- figure out how to stop execution
-			continue
+			pass
 
 	if args.key is None:
 		# Generate a random key

--- a/mono-substitution/mono.py
+++ b/mono-substitution/mono.py
@@ -7,7 +7,7 @@ def validate_key(key):
 		generated one by this program), check to see if the key is a valid key
 		for a monoalphabetic substitution cipher.
 	'''
-	pass
+	return True
 
 def generate_key():
 	'''
@@ -32,9 +32,11 @@ def decrypt(ciphertext):
 	pass
 
 def main():
+	'''
+		Main program execution, including the command-line interface and parsing
+		of the command-line arguments so program flow can be determined.
+	'''
 
-
-	# Command-line interface / command-line argument parsing
 	descrip = 'A monoalphabetic substitution encrypter/decrypter. It is capable ' \
 			  'of encrypting with your key of choice or a with a key generated ' \
 			  'randomly by this program. It can read in a file or a string passed ' \
@@ -51,8 +53,8 @@ def main():
 	parser = argparse.ArgumentParser(description=descrip)
 
 	group_action = parser.add_mutually_exclusive_group(required=True)
-	group_action.add_argument('-e', '--encrypt', help=encrypt_help)
-	group_action.add_argument('-d', '--decrypt', help=decrypt_help)
+	group_action.add_argument('-e', '--encrypt', action='store_true', help=encrypt_help)
+	group_action.add_argument('-d', '--decrypt', action='store_true', help=decrypt_help)
 
 	group_input = parser.add_mutually_exclusive_group(required=True)
 	group_input.add_argument('-f', '--txt-file', help=file_help)
@@ -60,7 +62,7 @@ def main():
 
 	group_key = parser.add_mutually_exclusive_group(required=True)
 	group_key.add_argument('-k', '--key', help=key_help)
-	group_key.add_argument('-r', '--random-key', help=rand_key)
+	group_key.add_argument('-r', '--random-key', action='store_true', help=rand_key)
 
 	parser.add_argument('-o', '--out-file', help=out_file)
 
@@ -89,30 +91,42 @@ def main():
 	encrypt = False
 	decrypt = False
 
+	# Figure out whether we are encryption or decrypting
+	if args.encrypt == True:
+		encrypt = True
+	else:
+		decrypt = True
+
 	if args.txt_file is not None:
 		# An input text file was passed in as the text to encrypt
-		print('Got file:', args.txt_file)
 		file_name = args.txt_file
-	if args.out_file is not None:
-		# An output file name was specified
-		print('Got out file:', args.out_file)
-		out_file_name = args.out_file
+		print('Input file:', file_name)
+
 	if args.string is not None:
 		# A string was passed in as the text to encrypt
-		print('Got string:', args.string)
 		plaintext = args.string
+		print('Input string:', plaintext)
+
+	if args.out_file is not None:
+		# An output file name was specified
+		out_file_name = args.out_file
+		print('Output file:', out_file_name)
+
+	# Figure out if a key is specified or if a random key will have to be generated
 	if args.key is not None:
 		# A key was specified by the user to encrypt with
 		if validate_key(args.key) == True:
 			key = args.key
+			print("Key:", key)
 		else:
 			# An invalid key was passed in by the user, die gracefully w/ error message
-			print("implement this")
+			# Implement this -- figure out how to stop execution
+			continue
+
 	if args.key is None:
 		# Generate a random key
+		print("Generating a random key...")
 		key = generate_key
-
-
 
 
 if __name__ == '__main__':

--- a/mono-substitution/mono.py
+++ b/mono-substitution/mono.py
@@ -31,23 +31,34 @@ def decrypt(ciphertext):
 	'''
 	pass
 
-def main()
-	descript = ''
-	encrypt_help = ''
-	decrypt_help = ''
-	file_help = ''
-	string_help = ''
-	key_help = ''
-	rand_key = ''
-	out_file = ''
+def main():
+	descrip = 'A monoalphabetic substitution encrypter/decrypter. It is capable ' \
+			  'of encrypting with your key of choice or a with a key generated ' \
+			  'randomly by this program. It can read in a file or a string passed ' \
+			  'into the command line. If no output file is specified, the decryption' \
+			  'will be printed to STDOUT.'
+	encrypt_help = 'This flag specifies that the input will be encrypted.'
+	decrypt_help = 'This flag specifies that the output will be decrypted.'
+	file_help = 'The .txt file to be used as input.'
+	string_help = 'The string to be used as input.'
+	key_help = 'The key (as a string).'
+	rand_key = 'This flag specifies that the program must generate a random key.'
+	out_file = 'The output decryption file.'
 
 	parser = argparse.ArgumentParser(description=descrip)
-	parser.add_argument('-e', '--encrypt', help=encrypt_help)
-	parser.add_argument('-d', '--decrypt', help=decrypt_help)
-	parser.add_argument('-f', '--txt-file', help=file_help)
-	parser.add_argument('-s', '--string', help=string_help)
-	parser.add_arguemtn('-k', '--key', help=key_help)
-	parser.add_argument('-r', '--random-key', help=rand_key)
+
+	group_action = parser.add_mutually_exclusive_group(required=True)
+	group_action.add_argument('-e', '--encrypt', help=encrypt_help)
+	group_action.add_argument('-d', '--decrypt', help=decrypt_help)
+
+	group_input = parser.add_mutually_exclusive_group(required=True)
+	group_input.add_argument('-f', '--txt-file', help=file_help)
+	group_input.add_argument('-s', '--string', help=string_help)
+
+	group_key = parser.add_mutually_exclusive_group(required=True)
+	group_key.add_argument('-k', '--key', help=key_help)
+	group_key.add_argument('-r', '--random-key', help=rand_key)
+
 	parser.add_argument('-o', '--out-file', help=out_file)
 
 	args = parser.parse_args()
@@ -83,17 +94,18 @@ def main()
 		# An output file name was specified
 		print('Got out file:', args.out_file)
 		out_file_name = args.out_file
-	elif args.string is not None:
+	if args.string is not None:
 		# A string was passed in as the text to encrypt
 		print('Got string:', args.string)
 		plaintext = args.string
-	elif args.key is not None:
+	if args.key is not None:
 		# A key was specified by the user to encrypt with
 		if validate_key(args.key) == True:
 			key = args.key
 		else:
 			# An invalid key was passed in by the user, die gracefully w/ error message
-	elif args.key is None:
+			print("implement this")
+	if args.key is None:
 		# Generate a random key
 		key = generate_key
 

--- a/mono-substitution/mono.py
+++ b/mono-substitution/mono.py
@@ -32,6 +32,9 @@ def decrypt(ciphertext):
 	pass
 
 def main():
+
+
+	# Command-line interface / command-line argument parsing
 	descrip = 'A monoalphabetic substitution encrypter/decrypter. It is capable ' \
 			  'of encrypting with your key of choice or a with a key generated ' \
 			  'randomly by this program. It can read in a file or a string passed ' \

--- a/mono-substitution/mono.py
+++ b/mono-substitution/mono.py
@@ -42,12 +42,12 @@ def main():
 			  'randomly by this program. It can read in a file or a string passed ' \
 			  'into the command line. If no output file is specified, the decryption ' \
 			  'will be printed to STDOUT.'
-	encrypt_help = 'This flag specifies that the input will be encrypted.'
-	decrypt_help = 'This flag specifies that the output will be decrypted.'
+	encrypt_help = 'Encrypt the input.'
+	decrypt_help = 'Decrypt the input.'
 	file_help = 'The .txt file to be used as input.'
 	string_help = 'The string to be used as input.'
 	key_help = 'The key (as a string).'
-	rand_key = 'This flag specifies that the program must generate a random key.'
+	rand_key = 'Generate a random key to encrypt with.'
 	out_file = 'The output decryption file.'
 
 	parser = argparse.ArgumentParser(description=descrip)

--- a/mono-substitution/mono.py
+++ b/mono-substitution/mono.py
@@ -16,7 +16,7 @@ def generate_key():
 	'''
 	pass
 
-# Obviously other functions will have to be created
+# Draw the rest of the fucking owl
 
 def encrypt(plaintext, key):
 	'''

--- a/mono-substitution/mono.py
+++ b/mono-substitution/mono.py
@@ -1,5 +1,6 @@
 import argparse
 
+
 def validate_key(key):
 	'''
 		In the case that a key was specified by the user (i.e., not a randomly
@@ -10,20 +11,30 @@ def validate_key(key):
 
 def generate_key():
 	'''
-		Return a key to encrypt with, generated (psuedo)randomly.
+		If the user did not specify a key to encrypt with, generate one
+		randomly and return the key.
 	'''
 	pass
 
 # Obviously other functions will have to be created
 
-
 def encrypt(plaintext, key):
+	'''
+		Given the plaintext, return the ciphertext as encrypted
+		with the key 'key'.
+	'''
 	pass
 
 def decrypt(ciphertext):
+	'''
+		Given the ciphertext, return the plaintext.
+	'''
+	pass
 
 def main()
 	descript = ''
+	encrypt_help = ''
+	decrypt_help = ''
 	file_help = ''
 	string_help = ''
 	key_help = ''
@@ -31,7 +42,8 @@ def main()
 	out_file = ''
 
 	parser = argparse.ArgumentParser(description=descrip)
-	parser
+	parser.add_argument('-e', '--encrypt', help=encrypt_help)
+	parser.add_argument('-d', '--decrypt', help=decrypt_help)
 	parser.add_argument('-f', '--txt-file', help=file_help)
 	parser.add_argument('-s', '--string', help=string_help)
 	parser.add_arguemtn('-k', '--key', help=key_help)
@@ -43,16 +55,19 @@ def main()
 	'''
 		Example inputs:
 
-		Passing in a file to decrypt with a specified key:
-			python mono.py -e -f <ciphertext.txt> -k 'bcdefjhijklmnopqrstuvwxyza' -o <plaintext.txt>
+		   1. Passing in a file to decrypt with a specified key:
 
-		Passing in a string to encrypt with a random key:
-			python mono.py -d -s 'Encrypt me, please.' -r -o <ciphertext.txt>
+				$ python mono.py -e -f <ciphertext.txt> -k 'bcdefjhijklmnopqrstuvwxyza' -o <plaintext.txt>
 
-		If no output file is specified with '-o', print the ciphertext to STDOUT.
+		   2. Passing in a string to encrypt with a random key:
+
+				$ python mono.py -d -s 'Encrypt me, please.' -r -o <ciphertext.txt>
+
+		If no output file is specified with '-o', print the cipher/plaintext to STDOUT.
 	'''
 
 	file_name = ''
+	out_file_name = ''
 	plaintext = ''
 	key = ''
 
@@ -64,12 +79,24 @@ def main()
 		# An input text file was passed in as the text to encrypt
 		print('Got file:', args.txt_file)
 		file_name = args.txt_file
+	if args.out_file is not None:
+		# An output file name was specified
+		print('Got out file:', args.out_file)
+		out_file_name = args.out_file
 	elif args.string is not None:
 		# A string was passed in as the text to encrypt
 		print('Got string:', args.string)
 		plaintext = args.string
 	elif args.key is not None:
 		# A key was specified by the user to encrypt with
+		if validate_key(args.key) == True:
+			key = args.key
+		else:
+			# An invalid key was passed in by the user, die gracefully w/ error message
+	elif args.key is None:
+		# Generate a random key
+		key = generate_key
+
 
 
 

--- a/mono-substitution/monoalphabetic_sub_cipher.py
+++ b/mono-substitution/monoalphabetic_sub_cipher.py
@@ -1,18 +1,76 @@
 import argparse
 
+def validate_key(key):
+	'''
+		In the case that a key was specified by the user (i.e., not a randomly
+		generated one by this program), check to see if the key is a valid key
+		for a monoalphabetic substitution cipher.
+	'''
+	pass
+
+def generate_key():
+	'''
+		Return a key to encrypt with, generated (psuedo)randomly.
+	'''
+	pass
+
+# Obviously other functions will have to be created
+
+
+def encrypt(plaintext, key):
+	pass
+
+def decrypt(ciphertext):
 
 def main()
 	descript = ''
 	file_help = ''
+	string_help = ''
 	key_help = ''
 	rand_key = ''
 	out_file = ''
 
 	parser = argparse.ArgumentParser(description=descrip)
+	parser
 	parser.add_argument('-f', '--txt-file', help=file_help)
+	parser.add_argument('-s', '--string', help=string_help)
 	parser.add_arguemtn('-k', '--key', help=key_help)
 	parser.add_argument('-r', '--random-key', help=rand_key)
 	parser.add_argument('-o', '--out-file', help=out_file)
+
+	args = parser.parse_args()
+
+	'''
+		Example inputs:
+
+		Passing in a file to decrypt with a specified key:
+			python mono.py -e -f <ciphertext.txt> -k 'bcdefjhijklmnopqrstuvwxyza' -o <plaintext.txt>
+
+		Passing in a string to encrypt with a random key:
+			python mono.py -d -s 'Encrypt me, please.' -r -o <ciphertext.txt>
+
+		If no output file is specified with '-o', print the ciphertext to STDOUT.
+	'''
+
+	file_name = ''
+	plaintext = ''
+	key = ''
+
+	# Flags for whether we are encrypting or decrypting
+	encrypt = False
+	decrypt = False
+
+	if args.txt_file is not None:
+		# An input text file was passed in as the text to encrypt
+		print('Got file:', args.txt_file)
+		file_name = args.txt_file
+	elif args.string is not None:
+		# A string was passed in as the text to encrypt
+		print('Got string:', args.string)
+		plaintext = args.string
+	elif args.key is not None:
+		# A key was specified by the user to encrypt with
+
 
 
 if __name__ == '__main__':

--- a/mono-substitution/monoalphabetic_sub_cipher.py
+++ b/mono-substitution/monoalphabetic_sub_cipher.py
@@ -1,0 +1,19 @@
+import argparse
+
+
+def main()
+	descript = ''
+	file_help = ''
+	key_help = ''
+	rand_key = ''
+	out_file = ''
+
+	parser = argparse.ArgumentParser(description=descrip)
+	parser.add_argument('-f', '--txt-file', help=file_help)
+	parser.add_arguemtn('-k', '--key', help=key_help)
+	parser.add_argument('-r', '--random-key', help=rand_key)
+	parser.add_argument('-o', '--out-file', help=out_file)
+
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
I began work on the monoalphabetic 'cryptogram' substitution solver.

I finished the command line interface and command line argument parsing.

```bash
$ python3 mono.py  -h
```
yields:

```bash
usage: mono.py [-h] (-e | -d) (-f TXT_FILE | -s STRING) (-k KEY | -r)
               [-o OUT_FILE]

A monoalphabetic substitution encrypter/decrypter. It is capable of encrypting
with your key of choice or a with a key generated randomly by this program. It
can read in a file or a string passed into the command line. If no output file
is specified, the decryption will be printed to STDOUT.

optional arguments:
  -h, --help            show this help message and exit
  -e, --encrypt         This flag specifies that the input will be encrypted.
  -d, --decrypt         This flag specifies that the output will be decrypted.
  -f TXT_FILE, --txt-file TXT_FILE
                        The .txt file to be used as input.
  -s STRING, --string STRING
                        The string to be used as input.
  -k KEY, --key KEY     The key (as a string).
  -r, --random-key      This flag specifies that the program must generate a
                        random key.
  -o OUT_FILE, --out-file OUT_FILE
                        The output decryption file.

```

I've also laid out some functions and their comments.